### PR TITLE
Remove Node.js 16 support, and add Node.js 19 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,15 +18,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: 'Node.js 16'
-            os: ubuntu-latest
-            nodejs: '16'
           - name: 'Node.js 18'
             os: ubuntu-latest
             nodejs: '18'
+          - name: 'Node.js 19'
+            os: ubuntu-latest
+            nodejs: '19'
           - name: 'Windows'
             os: windows-latest
-            nodejs: '18'
+            nodejs: '19'
 
     steps:
       - name: Check out the source code

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ default implementation on top of [Bootstrap](https://getbootstrap.com/).
 
 #### Requirements
 
-- [Node.js](https://nodejs.org/) 16 or newer
+- [Node.js](https://nodejs.org/) 18 or newer
 - npm or a compatible package manager
 
 #### Installation

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/nihruk/design-system/issues"
   },
   "homepage": "https://design-system.nihr.ac.uk/",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "start": "webpack-dev-server --open",
     "build": "del-cli dist && webpack -p",


### PR DESCRIPTION
Node.js 16 will be EOL in September 2023. Node.js 19 has been out since October 2022.