### PR TITLE
Replace usage of Github Actions' deprecated set-output with environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,13 @@ jobs:
           node-version: ${{ matrix.nodejs }}
 
       - name: Get the npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "npm_cache_dir=$(npm config get cache)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Cache npm
         uses: actions/cache@v3
         with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          path: ${{ env.npm_cache_dir }}
           key: npm-${{ hashFiles('./package.json') }}
           restore-keys: |
             npm-


### PR DESCRIPTION
This address the deprecation notices during our Github Actions builds.