### PR TITLE
Show available Nunjucks code in examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "glob": "^10.2.1",
     "highlight.js": "^11.7.0",
     "mini-css-extract-plugin": "^2.7.2",
+    "marked": "^4.3.0",
     "nunjucks": "^3.2.3",
     "postcss-loader": "^7.0.2",
     "postcss-preset-env": "^8.0.1",

--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -158,7 +158,11 @@ h6 {
   }
 }
 
-p {
+p,
+code,
+kbd,
+pre,
+samp {
   font-size: 1.125rem; // 18px
   line-height: 1.333; // 24px
   margin-bottom: 1.5rem; // 24px

--- a/src/docs/macros/component/_example-css.html
+++ b/src/docs/macros/component/_example-css.html
@@ -1,0 +1,1 @@
+<pre class="example-code p-3">{{ example.code | prettier('css') | highlight('css') | safe }}</pre>

--- a/src/docs/macros/component/_example-html.html
+++ b/src/docs/macros/component/_example-html.html
@@ -1,0 +1,1 @@
+<pre class="example-code p-3">{{ example.code | prettier('html') | highlight('html') | safe }}</pre>

--- a/src/docs/macros/component/_example-js.html
+++ b/src/docs/macros/component/_example-js.html
@@ -1,0 +1,1 @@
+<pre class="example-code p-3">{{ example.code | prettier('babel') | highlight('js') | safe }}</pre>

--- a/src/docs/macros/component/_example-nunjucks.html
+++ b/src/docs/macros/component/_example-nunjucks.html
@@ -1,0 +1,56 @@
+{% from 'macros/component/accordion.html' import accordion %}
+
+{% macro _options(tags) %}
+<dl class="component-options">
+       {% for tag in tags %}
+              <dt>
+                     <code>{{ tag.name }}: {{ tag.type }}{% if tag.optional %}{% if tag.default is defined %} = {{ tag.default }}{% else %}null{% endif %}{% endif %}</code>
+              </dt>
+              <dd>
+                     {{ tag.description | deindent | markdown | safe }}
+              </dd>
+       {% endfor %}
+</dl>
+{% endmacro %}
+
+{% if example.nunjucksMacro is defined %}
+       {% set jsDocs = example.nunjucksMacro | nunjucksMacroJsDocs %}
+       {% set types = [] %}
+       {% set typesOptions = {} %}
+       {% for tag in jsDocs.tags %}
+              {% if tag.tag == 'typedef' %}
+                     {% set _ = types.push(tag) %}
+                     {% set currentType = tag %}
+              {% endif %}
+              {% if tag.tag == 'property' and currentType is defined %}
+                     {% set _ = typesOptions | setKey(currentType.name, typesOptions[currentType.name] | default([])) %}
+                     {% set _ = typesOptions[currentType.name].push(tag) %}
+              {% endif %}
+       {% endfor %}
+       <div class="example-instructions px-3">
+              {% set macroOptions %}
+                     {% set macroOptions = [] %}
+                     {% for tag in jsDocs.tags %}
+                            {% if tag.tag == 'param' %}
+                                   {% set _ = macroOptions.push(tag) %}
+                            {% endif %}
+                     {% endfor %}
+                     <p class="h6 mb-0">Options to the <code>{{ example.nunjucksMacro.split('/') | last | kebabCaseToLowerCamelCase }}()</code> macro</p>
+                     {{ _options(macroOptions) }}
+                     {% for typeName, typeOptions in typesOptions %}
+                            <p class="h6 mb-0">Options to <code>{{ typeName }}</code></p>
+                            {{ _options(typeOptions) }}
+                     {% endfor %}
+              {% endset %}
+              {{ accordion({
+                     'id': options.id ~ '-nunjucks-macro-options',
+                     'items': [
+                            {
+                                   'header': 'Macro options',
+                                   'body': macroOptions | safe
+                            }
+                     ]
+              }) }}
+       </div>
+{% endif %}
+<pre class="example-code p-3">{{ example.code | highlight('twig') | safe }}</pre>

--- a/src/docs/macros/component/example.html
+++ b/src/docs/macros/component/example.html
@@ -1,0 +1,79 @@
+{#
+@macro example
+@param {string} id
+       The ID of the root HTML element.
+@param {Array<object>} examples
+       The examples to show. Each item is an object with `{string} code` and `{string} type` properties, which are
+       the source code and one of `html`, `nunjucks`, `css`, or `js` respectively.
+
+       Items with `.type = 'html'` also have a `{boolean} [htmlRender=true]` property that indicates whether the
+       example must also be rendered interactively.
+
+       Items with `.type = 'nunjucks'` also have a `{string} nunjucksMacro` property that contains the name of the
+       Nunjucks macro used by this example. This ensures the macro is imported, and its documentation rendered.
+#}
+{% macro example(options) %}
+{% set typeLabels = {
+       'html': 'HTML',
+       'nunjucks': 'Nunjucks',
+       'css': 'CSS',
+       'js': 'JS'
+} %}
+
+
+{% for example in options.examples %}
+       {% set _ = example | setKey ('code', example.code | trim) %}
+       {# Expand any Nunjucks examples to include an optional macro import. #}
+       {% if example.type == 'nunjucks' and example.nunjucksMacro is defined %}
+              {% set _ = example | setKey ('code', '{% from \'macros/' ~ example.nunjucksMacro ~ '.html\' import ' ~ example.nunjucksMacro.split('/') | last | kebabCaseToLowerCamelCase ~ ' %}\n\n' ~ example.code) %}
+       {% endif %}
+{% endfor %}
+
+{# Collect all examples that can be shown as rendered HTML. #}
+{% set renderableHtmlExamples = [] %}
+{% for example in options.examples %}
+       {% if example.type == 'html' and example.htmlRender | default(true) %}
+              {% set _ = renderableHtmlExamples.push(example) %}
+       {% endif %}
+{% endfor %}
+
+{# If there are no (renderable) HTML examples, try and convert another example to (renderable) HTML. #}
+{% for example in options.examples %}
+       {% if renderableHtmlExamples | first is undefined %}
+              {% if example.type == 'nunjucks' %}
+                     {% set renderableHtmlExample = {
+                            'type': 'html',
+                            'code': example.code | nunjucks
+                     } %}
+                     {% set _ = options.examples.unshift(renderableHtmlExample) %}
+                     {% set _ = renderableHtmlExamples.push(renderableHtmlExample) %}
+              {% endif %}
+       {% endif %}
+{% endfor %}
+
+<div class="example rounded mb-3">
+       {# Show a rendered HTML example, if one can be rendered. #}
+       {% set renderableHtmlExample = renderableHtmlExamples | first %}
+       {% if renderableHtmlExample is not undefined %}
+              <div class="example-html-render p-3">{{ renderableHtmlExample.code | safe }}</div>
+       {% endif %}
+
+       {# Show all examples. #}
+       <div class="examples bg-white">
+              <ul class="nav nav-pills mb-0 p-3" id="pills-tab--{{ options.id }}" role="tablist">
+                     {% for example in options.examples %}
+                            <li class="nav-item" role="presentation">
+                                   <button class="nav-link rounded-0{% if loop.index == 1%} active{% endif %}" id="pills-tab--{{ options.id }}--{{ loop.index }}" data-bs-toggle="pill" data-bs-target="#pills--{{ options.id }}--{{ loop.index }}" type="button" role="tab" aria-controls="pills--{{ options.id }}--{{ loop.index }}"{% if loop.index == 1%} aria-selected="true"{% endif %}>{{ typeLabels[example.type] }}</button>
+                            </li>
+                     {% endfor %}
+              </ul>
+              <div class="tab-content" id="pills-tabContent--{{ options.id }}">
+                     {% for example in options.examples %}
+                            <div class="tab-pane fade{% if loop.index == 1%} show active{% endif %}" id="pills--{{ options.id }}--{{ loop.index }}" role="tabpanel" aria-labelledby="pills-profile-tab" tabindex="0">
+                                   {% include 'docs/macros/component/_example-' ~ example.type ~ '.html'%}
+                            </div>
+                     {% endfor %}
+              </div>
+       </div>
+</div>
+{% endmacro %}

--- a/src/docs/partials/css-example--code.html
+++ b/src/docs/partials/css-example--code.html
@@ -1,1 +1,0 @@
-<pre class="example-code">{{ code | prettier('css') | highlight('css') | safe }}</pre>

--- a/src/docs/partials/example.html
+++ b/src/docs/partials/example.html
@@ -1,2 +1,0 @@
-<p class="example-caption">Example</p>
-<div class="example">{{ code | safe }}</div>

--- a/src/docs/partials/html-example--code.html
+++ b/src/docs/partials/html-example--code.html
@@ -1,1 +1,0 @@
-<pre class="example-code">{{ code | prettier('html') | highlight('html') | safe }}</pre>

--- a/src/docs/partials/html-example.html
+++ b/src/docs/partials/html-example.html
@@ -1,2 +1,0 @@
-{% include 'docs/partials/example.html' %}
-{% include 'docs/partials/html-example--code.html' %}

--- a/src/docs/partials/js-example--code.html
+++ b/src/docs/partials/js-example--code.html
@@ -1,1 +1,0 @@
-<pre class="example-code">{{ code | prettier('babel') | highlight('js') | safe }}</pre>

--- a/src/docs/scss/main.scss
+++ b/src/docs/scss/main.scss
@@ -1,5 +1,5 @@
 @import 'highlight.js/styles/github.css';
-@import '../../assets/scss/abstracts/sass-variables';
+@import '../../assets/scss/theme.scss';
 
 
 .ds-color-specifications dt:not(:first-child)::before {
@@ -17,21 +17,19 @@
 }
 
 .example {
-  border: 2px solid $navy-60;
-  padding: 2px;
+  border: 2px solid $navy-20;
 }
 
-.example-caption {
-  color: $navy-100;
-  border-left: 2px solid $navy-60;
-  margin-bottom: 0;
-  padding-left: 1rem;
+.example-html-render {
+  border-bottom: 2px solid $navy-20;
 }
 
 .example-code {
   background-color: $grey-20;
-  border-left: 2px solid $navy-60;
   max-height: 20rem;
-  overflow: scoll;
-  padding: 1rem;
+  overflow: scroll;
+}
+
+.component-options {
+  border-top: 2px solid $navy-20;
 }

--- a/src/docs/www/component/accordion/index.html
+++ b/src/docs/www/component/accordion/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/accordion.html' import accordion %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title='Accordion' %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -6,87 +7,111 @@
     Accordions collapse content that may not be relevant to all audiences.
   </p>
 
-  {% set code %}
-    {{ accordion({
-        'id': 'accordion-component-example-minimal',
-        'items': [
+    {{ example({
+        'id': 'example-accordion-component-minimal',
+        'examples': [
           {
-            'header': 'More content',
-            'body': '
+            'type': 'nunjucks',
+            'nunjucksMacro': 'component/accordion',
+            'code': "
+{{ accordion({
+    'id': 'accordion-component-minimal',
+    'items': [
+      {
+        'header': 'More content',
+        'body': '
 <p>
-  Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nulla nisi veniam doloribus corrupti
-  ut dolores debitis, quos excepturi assumenda sit praesentium ab culpa soluta, et asperiores?
-  Autem ea quo repellendus.
+Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nulla nisi veniam doloribus corrupti
+ut dolores debitis, quos excepturi assumenda sit praesentium ab culpa soluta, et asperiores?
+Autem ea quo repellendus.
 </p>
-            ' | safe
-          },
-          {
-            'header': 'Even more content',
-            'body': '
+        ' | safe
+      },
+      {
+        'header': 'Even more content',
+        'body': '
 <p>
-  Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nulla nisi veniam doloribus corrupti
-  ut dolores debitis, quos excepturi assumenda sit praesentium ab culpa soluta, et asperiores?
-  Autem ea quo repellendus.
+Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nulla nisi veniam doloribus corrupti
+ut dolores debitis, quos excepturi assumenda sit praesentium ab culpa soluta, et asperiores?
+Autem ea quo repellendus.
 </p>
-            ' | safe
+        ' | safe
+      }
+    ]
+}) }}
+            "
           }
         ]
     }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
 
   <h2>Showing items by default</h2>
-  {% set code %}
-    {{ accordion({
-        'id': 'accordion-component-example-show',
-        'items': [
+    {{ example({
+        'id': 'example-accordion-component-show',
+        'examples': [
           {
-            'header': 'More content',
-            'body': '
+            'type': 'nunjucks',
+            'nunjucksMacro': 'component/accordion',
+            'code': "
+{{ accordion({
+    'id': 'accordion-component-show',
+    'items': [
+      {
+        'header': 'More content',
+        'body': '
 <p>
-  Lorem ipsum, dolor sit amet.
+Lorem ipsum, dolor sit amet.
 </p>
-            ' | safe
-          },
-          {
-            'header': 'Even more content',
-            'body': '
+        ' | safe
+      },
+      {
+        'header': 'Even more content',
+        'body': '
 <p>
-  Lorem ipsum, dolor sit amet.
+Lorem ipsum, dolor sit amet.
 </p>
-            ' | safe,
-            'show': true
+        ' | safe,
+        'show': true
+      }
+    ]
+}) }}
+            "
           }
         ]
     }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
 
   <h2>Mutually exclusive items</h2>
-  {% set code %}
-    {{ accordion({
-        'id': 'accordion-component-example-mutually-exclusive',
-        'mutuallyExclusive': true,
-        'items': [
+    {{ example({
+        'id': 'example-accordion-component-mutually-exclusive',
+        'examples': [
           {
-            'header': 'More content',
-            'body': '
+            'type': 'nunjucks',
+            'nunjucksMacro': 'component/accordion',
+            'code': "
+{{ accordion({
+    'id': 'accordion-component-mutually-exclusive',
+    'mutuallyExclusive': true,
+    'items': [
+      {
+        'header': 'More content',
+        'body': '
 <p>
-  Lorem ipsum, dolor sit amet.
+Lorem ipsum, dolor sit amet.
 </p>
-            ' | safe,
-            'show': true
-          },
-          {
-            'header': 'Even more content',
-            'body': '
+        ' | safe,
+        'show': true
+      },
+      {
+        'header': 'Even more content',
+        'body': '
 <p>
-  Lorem ipsum, dolor sit amet.
+Lorem ipsum, dolor sit amet.
 </p>
-            ' | safe
+        ' | safe
+      }
+    ]
+}) }}
+            "
           }
         ]
     }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
 {% endblock %}

--- a/src/docs/www/component/alert/index.html
+++ b/src/docs/www/component/alert/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/alert.html' import alert %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Alert" %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -30,24 +31,31 @@
   </p>
 
   <h2>Examples</h2>
-
-  {% set code %}
-    {{ alert({
-      'type': 'info',
-      'body': 'Updates are available'
-    }) }}
-    {{ alert({
-      'type': 'success',
-      'body': 'Updates were made successfully'
-    }) }}
-    {{ alert({
-      'type': 'warning',
-      'body': 'Updates have not been run recently'
-    }) }}
-    {{ alert({
-      'type': 'danger',
-      'body': 'An error occurred while updating'
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-alert-component',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/alert',
+              'code': "
+{{ alert({
+  'type': 'info',
+  'body': 'Updates are available'
+}) }}
+{{ alert({
+  'type': 'success',
+  'body': 'Updates were made successfully'
+}) }}
+{{ alert({
+  'type': 'warning',
+  'body': 'Updates have not been run recently'
+}) }}
+{{ alert({
+  'type': 'danger',
+  'body': 'An error occurred while updating'
+}) }}
+              "
+          }
+      ]
+}) }}
 {% endblock %}

--- a/src/docs/www/component/button/index.html
+++ b/src/docs/www/component/button/index.html
@@ -1,3 +1,4 @@
+{% from 'docs/macros/component/example.html' import example %}
 {% from 'macros/component/button.html' import button %}
 {% set title="Button" %}
 {% extends 'docs/partials/component-page.html' %}
@@ -228,11 +229,19 @@
 
   <p>In some contexts you may want to display a larger than usual button, for example as a Call To Action.</p>
 
-  {% set code %}
-    {{ button({
-      'label': 'Button',
-      'large': true
+    {{ example({
+        'id': 'example-button-component-large',
+        'examples': [
+          {
+            'type': 'nunjucks',
+            'nunjucksMacro': 'component/button',
+            'code': "
+{{ button({
+  'label': 'Button',
+  'large': true
+}) }}
+            "
+          }
+        ]
     }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
 {% endblock %}

--- a/src/docs/www/component/checkbox/index.html
+++ b/src/docs/www/component/checkbox/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/checkbox.html' import checkbox %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Checkbox" %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -84,41 +85,73 @@
 
   <h2>Examples</h2>
   <h3>Minimal checkbox</h3>
-  {% set code %}
-    {{ checkbox({
-      'label': 'I want to receive the NIHR newsletter',
-      'value': 'yes'
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-checkbox-component-minimal',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/checkbox',
+              'code': "
+{{ checkbox({
+  'label': 'I want to receive the NIHR newsletter',
+  'value': 'yes'
+}) }}
+              "
+          }
+      ]
+  }) }}
 
   <h3>Required checkbox</h3>
-  {% set code %}
-    {{ checkbox({
-      'label': 'I want to receive the NIHR newsletter',
-      'value': 'yes',
-      'required': true
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-checkbox-component-required',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/checkbox',
+              'code': "
+{{ checkbox({
+  'label': 'I want to receive the NIHR newsletter',
+  'value': 'yes',
+  'required': true
+}) }}
+              "
+          }
+      ]
+  }) }}
 
   <h3>Invalid checkbox</h3>
-  {% set code %}
-    {{ checkbox({
-      'label': 'I want to receive the NIHR newsletter',
-      'value': 'yes',
-      'invalid': true
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-checkbox-component-invalid',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/checkbox',
+              'code': "
+{{ checkbox({
+  'label': 'I want to receive the NIHR newsletter',
+  'value': 'yes',
+  'invalid': true
+}) }}
+              "
+          }
+      ]
+  }) }}
 
   <h3>Disabled checkbox</h3>
-  {% set code %}
-    {{ checkbox({
-      'label': 'I want to receive the NIHR newsletter',
-      'value': 'yes',
-      'disabled': true
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-checkbox-component-disabled',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/checkbox',
+              'code': "
+{{ checkbox({
+  'label': 'I want to receive the NIHR newsletter',
+  'value': 'yes',
+  'disabled': true
+}) }}
+              "
+          }
+      ]
+  }) }}
 {% endblock %}

--- a/src/docs/www/component/explore/index.html
+++ b/src/docs/www/component/explore/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/explore.html' import explore %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title='Explore' %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -54,67 +55,78 @@
   <h2>Examples</h2>
 
   {% set code %}
-    {{ explore({
-      'first': {
-        'heading': 'NIHR',
-        'links': [
-          {
-            'label': 'Research funding',
-            'href': '#_'
-          },
-          {
-            'label': 'Career development',
-            'href': '#_'
-          },
-          {
-            'label': 'Infrastructure funding',
-            'href': '#_'
-          },
-          {
-            'label': 'Funding opportunities',
-            'href': '#_'
-          }
-        ]
-      },
-      'middle': {
-        'heading': 'NIHR open data',
-        'links': [
-          {
-            'label': 'About NIHR open data',
-            'href': '#_'
-          },
-          {
-            'label': 'NIHR data',
-            'href': '#_'
-          },
-          {
-            'label': 'NIHR awards',
-            'href': '#_'
-          },
-          {
-            'label': 'NIHR maps',
-            'href': '#_'
-          }
-        ]
-      },
-      'last': {
-        'heading': 'Journals Library',
-        'links': [
-          {
-            'label': 'Five open access journals',
-            'href': '#_'
-          },
-          {
-            'label': 'For authors',
-            'href': '#_'
-          },
-          {
-            'label': 'For reviewers',
-            'href': '#_'
-          }
-        ]
-      }
-    }) }}
+    {% raw %}
+      {{ explore({
+        'first': {
+          'heading': 'NIHR',
+          'links': [
+            {
+              'label': 'Research funding',
+              'href': '#_'
+            },
+            {
+              'label': 'Career development',
+              'href': '#_'
+            },
+            {
+              'label': 'Infrastructure funding',
+              'href': '#_'
+            },
+            {
+              'label': 'Funding opportunities',
+              'href': '#_'
+            }
+          ]
+        },
+        'middle': {
+          'heading': 'NIHR open data',
+          'links': [
+            {
+              'label': 'About NIHR open data',
+              'href': '#_'
+            },
+            {
+              'label': 'NIHR data',
+              'href': '#_'
+            },
+            {
+              'label': 'NIHR awards',
+              'href': '#_'
+            },
+            {
+              'label': 'NIHR maps',
+              'href': '#_'
+            }
+          ]
+        },
+        'last': {
+          'heading': 'Journals Library',
+          'links': [
+            {
+              'label': 'Five open access journals',
+              'href': '#_'
+            },
+            {
+              'label': 'For authors',
+              'href': '#_'
+            },
+            {
+              'label': 'For reviewers',
+              'href': '#_'
+            }
+          ]
+        }
+      }) }}
+    {% endraw %}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-explore-other-sites-component',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/explore',
+              'code': code
+          }
+      ]
+}) }}
 {% endblock %}

--- a/src/docs/www/component/footer/index.html
+++ b/src/docs/www/component/footer/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/footer.html' import footer %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Footer" %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -56,7 +57,16 @@
   {% set code %}
     {{ footer() }}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-footer-component-minimal',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/footer',
+              'code': code
+          }
+      ]
+  }) }}
 
   <h3>Additional social media links</h3>
   {% set code %}
@@ -73,7 +83,16 @@
       ]
     }) }}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-footer-component-additional-social-media-links',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/footer',
+              'code': code
+          }
+      ]
+  }) }}
 
   <h3>Navigation links</h3>
   {% set code %}
@@ -86,7 +105,16 @@
       ]
     }) }}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-footer-component-navigation-links',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/footer',
+              'code': code
+          }
+      ]
+  }) }}
 
   <h3>Body content</h3>
   {% set code %}
@@ -175,5 +203,14 @@
       ' | safe
     }) }}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-footer-component-body',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/footer',
+              'code': code
+          }
+      ]
+  }) }}
 {% endblock %}

--- a/src/docs/www/component/header/index.html
+++ b/src/docs/www/component/header/index.html
@@ -1,3 +1,4 @@
+{% from 'docs/macros/component/example.html' import example %}
 {% from 'macros/component/header.html' import header %}
 {% set title="Header" %}
 {% extends 'docs/partials/component-page.html' %}
@@ -22,20 +23,32 @@
     <h2>Examples</h2>
 
     <h3>Default header</h3>
-
-    {% set code %}
-        {{ header() }}
-    {% endset %}
-    {% include 'docs/partials/html-example.html' %}
+    {{ example({
+      'id': 'example-header-component',
+      'examples': [
+        {
+          'type': 'nunjucks',
+          'nunjucksMacro': 'component/header',
+          'code': '{{ header() }}'
+        }
+      ]
+    }) }}
 
     <h3>Header with search</h3>
-
-    {% set code %}
-        {{ header({
-            'search': {
-                'action': '#'
+    {{ example({
+      'id': 'example-header-component-with-search',
+      'examples': [
+            {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/header',
+              'code': "
+{{ header({
+    'search': {
+        'action': '#'
+    }
+}) }}
+              "
             }
-        }) }}
-    {% endset %}
-    {% include 'docs/partials/html-example.html' %}
+        ]
+    }) }}
 {% endblock %}

--- a/src/docs/www/component/search/index.html
+++ b/src/docs/www/component/search/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/search.html' import search %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title='Search' %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -15,7 +16,16 @@
             'action': '#'
         }) }}
     {% endset %}
-    {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-search-input-component',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/search',
+              'code': code
+          }
+      ]
+  }) }}
 
     <h3>Large Search</h3>
 
@@ -25,5 +35,14 @@
             'large': true
         }) }}
     {% endset %}
-    {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-search-input-component-large',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/search',
+              'code': code
+          }
+      ]
+  }) }}
 {% endblock %}

--- a/src/docs/www/component/select-input/index.html
+++ b/src/docs/www/component/select-input/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/select-input.html' import selectInput %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Select Input" %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -32,71 +33,111 @@
 
   <h2>Examples</h2>
   <h3>Minimal input</h3>
-  {% set code %}
-    {{ selectInput({
-      'label': 'Colour',
-      'options': {
-        'red': 'Red',
-        'green': 'Green',
-        'blue': 'Blue'
-      }
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-select-input-component-minimal',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/select-input',
+              'code': "
+{{ selectInput({
+  'label': 'Colour',
+  'options': {
+    'red': 'Red',
+    'green': 'Green',
+    'blue': 'Blue'
+  }
+}) }}
+              "
+          }
+      ]
+  }) }}
 
   <h3>Required input</h3>
-  {% set code %}
-    {{ selectInput({
-      'label': 'Colour',
-      'options': {
-        'red': 'Red',
-        'green': 'Green',
-        'blue': 'Blue'
-      },
-      'required': true
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-select-input-component-required',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/select-input',
+              'code': "
+{{ selectInput({
+  'label': 'Colour',
+  'options': {
+    'red': 'Red',
+    'green': 'Green',
+    'blue': 'Blue'
+  },
+  'required': true
+}) }}
+              "
+          }
+      ]
+  }) }}
 
   <h3>Invalid input</h3>
-  {% set code %}
-    {{ selectInput({
-      'label': 'Colour',
-      'options': {
-        'red': 'Red',
-        'green': 'Green',
-        'blue': 'Blue'
-      },
-      'invalid': true
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-select-input-component-invalid',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/select-input',
+              'code': "
+{{ selectInput({
+  'label': 'Colour',
+  'options': {
+    'red': 'Red',
+    'green': 'Green',
+    'blue': 'Blue'
+  },
+  'invalid': true
+}) }}
+              "
+          }
+      ]
+  }) }}
 
   <h3>Disabled input</h3>
-  {% set code %}
-    {{ selectInput({
-      'label': 'Colour',
-      'options': {
-        'red': 'Red',
-        'green': 'Green',
-        'blue': 'Blue'
-      },
-      'disabled': true
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-select-input-component-disabled',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/select-input',
+              'code': "
+{{ selectInput({
+  'label': 'Colour',
+  'options': {
+    'red': 'Red',
+    'green': 'Green',
+    'blue': 'Blue'
+  },
+  'disabled': true
+}) }}
+              "
+          }
+      ]
+  }) }}
 
   <h3>Prepopulated input</h3>
-  {% set code %}
-    {{ selectInput({
-      'label': 'Colour',
-      'options': {
-        'red': 'Red',
-        'green': 'Green',
-        'blue': 'Blue'
-      },
-      'value': 'blue'
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-select-input-component-prepopulated',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/select-input',
+              'code': "
+{{ selectInput({
+  'label': 'Colour',
+  'options': {
+    'red': 'Red',
+    'green': 'Green',
+    'blue': 'Blue'
+  },
+  'value': 'blue'
+}) }}
+              "
+          }
+      ]
+  }) }}
 {% endblock %}

--- a/src/docs/www/component/table/index.html
+++ b/src/docs/www/component/table/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/table.html' import table %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Table" %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -37,87 +38,109 @@
   <h2>Examples</h2>
   <h3>A minimal table, with a caption</h3>
   {% set code %}
-    {{ table({
-      'caption': 'Some people in a table',
-      'head': [
-        [
-          'Name',
-          'Age'
+    {% raw %}
+      {{ table({
+        'caption': 'Some people in a table',
+        'head': [
+          [
+            'Name',
+            'Age'
+          ]
+        ],
+        'body': [
+          [
+            'Jane Doe',
+            '1'
+          ],
+          [
+            'Janet Doughnut',
+            '3'
+          ],
+          [
+            'John Doe',
+            '3'
+          ],
+          [
+            'Jeff Donut',
+            '7'
+          ]
         ]
-      ],
-      'body': [
-        [
-          'Jane Doe',
-          '1'
-        ],
-        [
-          'Janet Doughnut',
-          '3'
-        ],
-        [
-          'John Doe',
-          '3'
-        ],
-        [
-          'Jeff Donut',
-          '7'
-        ]
-      ]
-    }) }}
+      }) }}
+    {% endraw %}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-table-component-minimal-with-caption',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/table',
+              'code': code
+          }
+      ]
+  }) }}
 
   <h3>A table with a scoped column and row headers</h3>
   {% set code %}
-    {{ table({
-      'caption': 'Some people in a table',
-      'head': [
-        [
-          {
-            'body': 'Name',
-            'headerScope': 'col'
-          },
-          {
-            'body': 'Age',
-            'headerScope': 'col'
-          }
+    {% raw %}
+      {{ table({
+        'caption': 'Some people in a table',
+        'head': [
+          [
+            {
+              'body': 'Name',
+              'headerScope': 'col'
+            },
+            {
+              'body': 'Age',
+              'headerScope': 'col'
+            }
+          ]
+        ],
+        'body': [
+          [
+            {
+              'body': 'Jane Doe',
+              'header': true,
+              'headerScope': 'row'
+            },
+            '1'
+          ],
+          [
+            {
+              'body': 'Janet Doughnut',
+              'header': true,
+              'headerScope': 'row'
+            },
+            '3'
+          ],
+          [
+            {
+              'body': 'John Doe',
+              'header': true,
+              'headerScope': 'row'
+            },
+            '3'
+          ],
+          [
+            {
+              'body': 'Jeff Donut',
+              'header': true,
+              'headerScope': 'row'
+            },
+            '7'
+          ]
         ]
-      ],
-      'body': [
-        [
-          {
-            'body': 'Jane Doe',
-            'header': true,
-            'headerScope': 'row'
-          },
-          '1'
-        ],
-        [
-          {
-            'body': 'Janet Doughnut',
-            'header': true,
-            'headerScope': 'row'
-          },
-          '3'
-        ],
-        [
-          {
-            'body': 'John Doe',
-            'header': true,
-            'headerScope': 'row'
-          },
-          '3'
-        ],
-        [
-          {
-            'body': 'Jeff Donut',
-            'header': true,
-            'headerScope': 'row'
-          },
-          '7'
-        ]
-      ]
-    }) }}
+      }) }}
+    {% endraw %}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+      'id': 'example-table-component-scoped-headers',
+      'examples': [
+          {
+              'type': 'nunjucks',
+              'nunjucksMacro': 'component/table',
+              'code': code
+          }
+      ]
+  }) }}
 {% endblock %}

--- a/src/docs/www/component/text-input/index.html
+++ b/src/docs/www/component/text-input/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/text-input.html' import textInput %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Text Input" %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
@@ -74,45 +75,86 @@
 
   <h2>Examples</h2>
   <h3>Minimal input</h3>
-  {% set code %}
-    {{ textInput({
-      'label': 'Your full name'
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+    'id': 'example-text-input-component-minimal',
+    'examples': [
+      {
+        'type': 'nunjucks',
+        'nunjucksMacro': 'component/text-input',
+        'code': "
+{{ textInput({
+  'label': 'Your full name'
+}) }}
+        "
+      }
+    ]
+  }) }}
 
   <h3>Required input</h3>
-  {% set code %}
-    {{ textInput({
-      'label': 'Your full name',
-      'required': true
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+    'id': 'example-text-input-component-required',
+    'examples': [
+          {
+            'type': 'nunjucks',
+            'nunjucksMacro': 'component/text-input',
+            'code': "
+{{ textInput({
+  'label': 'Your full name',
+  'required': true
+}) }}
+            "
+          }
+      ]
+  }) }}
 
   <h3>Invalid input</h3>
-  {% set code %}
-    {{ textInput({
-      'label': 'Your full name',
-      'invalid': true
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+    'id': 'example-text-input-component-invalid',
+    'examples': [
+          {
+            'type': 'nunjucks',
+            'nunjucksMacro': 'component/text-input',
+            'code': "
+{{ textInput({
+  'label': 'Your full name',
+  'invalid': true
+}) }}
+            "
+          }
+      ]
+  }) }}
 
   <h3>Disabled input</h3>
-  {% set code %}
-    {{ textInput({
-      'label': 'Your full name',
-      'disabled': true
-    }) }}
-  {% endset %}
+  {{ example({
+    'id': 'example-text-input-component-disabled',
+    'examples': [
+          {
+            'type': 'nunjucks',
+            'nunjucksMacro': 'component/text-input',
+            'code': "
+{{ textInput({
+  'label': 'Your full name',
+  'disabled': true
+}) }}
+            "
+          }
+      ]
+  }) }}
 
   <h3>Prepopulated input</h3>
-  {% set code %}
-    {{ textInput({
-      'label': 'Your full name',
-      'value': 'Jane Doe'
-    }) }}
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+  {{ example({
+    'id': 'example-text-input-component-prepopulated',
+    'examples': [
+          {
+            'type': 'nunjucks',
+            'nunjucksMacro': 'component/text-input',
+            'code': "
+{{ textInput({
+  'label': 'Your full name',
+  'value': 'Jane Doe'
+}) }}
+            "
+          }
+      ]
+  }) }}
 {% endblock %}

--- a/src/docs/www/get-started/install/index.html
+++ b/src/docs/www/get-started/install/index.html
@@ -17,11 +17,11 @@
     {% set code %}
         @import '~@nihruk/design-system/dist/design-system.bundle.css';
     {% endset %}
-    {% include 'docs/partials/css-example--code.html' %}
+    <pre class="example-code p-3">{{ code | prettier('css') | highlight('css') | safe }}</pre>
     {% set code %}
         import '~@nihruk/design-system/dist/design-system.bundle.js';
     {% endset %}
-    {% include 'docs/partials/js-example--code.html' %}
+    <pre class="example-code p-3">{{ code | prettier('babel') | highlight('js') | safe }}</pre>
 
     <h3>Bundling your application</h3>
     <p>
@@ -53,10 +53,11 @@
         <a href="https://www.npmjs.com/package/@nihruk/design-system?activeTab=versions">available versions</a>:
     </p>
     {% set code %}
-        <link rel="stylesheet" href="https://unpkg.com/@nihruk/design-system@x.y.z/dist/design-system.bundle.css" />
-        <script src="https://unpkg.com/@nihruk/design-system@x.y.z/dist/design-system.bundle.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@nihruk/design-system@x.y.z/dist/design-system.bundle.css" />
+<script src="https://unpkg.com/@nihruk/design-system@x.y.z/dist/design-system.bundle.js"></script>
     {% endset %}
-    {% include 'docs/partials/html-example--code.html' %}
+    <pre class="example-code p-3">{{ code | prettier('html') | highlight('html') | safe }}</pre>
+
     <h3>When not to include hosted files</h3>
     <p>
         You should not include the hosted files:

--- a/src/docs/www/style/layout/index.html
+++ b/src/docs/www/style/layout/index.html
@@ -1,3 +1,4 @@
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Layout" %}
 {% extends 'docs/partials/style-page.html' %}
 {% block stylePageContent %}
@@ -34,16 +35,32 @@
 
   <h2>Common Layouts</h2>
   <h3>Two-thirds</h3>
-  {% set code %}
+  {% set html %}
       {% include 'docs/partials/style/layout/two-thirds.html' %}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+    {{ example({
+      'id': 'example-layout-style-two-thirds',
+      'examples': [
+            {
+              'type': 'html',
+              'code': html
+            }
+        ]
+    }) }}
 
   <h3>Two-thirds and one-third</h3>
-  {% set code %}
+  {% set html %}
       {% include 'docs/partials/style/layout/two-thirds--one-third.html' %}
   {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+    {{ example({
+      'id': 'example-layout-style-two-thirds-and-one-third',
+      'examples': [
+            {
+              'type': 'html',
+              'code': html
+            }
+        ]
+    }) }}
 
   <h2>See also</h2>
   <ul>

--- a/src/docs/www/style/text/index.html
+++ b/src/docs/www/style/text/index.html
@@ -1,4 +1,5 @@
 {% from 'macros/component/table.html' import table %}
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Text types" %}
 {% extends 'docs/partials/style-page.html' %}
 
@@ -147,37 +148,58 @@
     You can use <code>&lt;strong&gt;</code> to mark text as important, or <code>&lt;b&gt;</code> to draw attention
     to text that is not otherwise important. For example:
   </p>
-  {% set code %}
-    <p>
-      Your reference number is <strong>ABC12345678</strong>. Use this to track your application.
-      Updates will be sent to <b>name@example.com</b>.
-    </p>
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+    {{ example({
+      'id': 'example-text-style-strong-and-b',
+      'examples': [
+            {
+              'type': 'html',
+              'code': '
+<p>
+  Your reference number is <strong>ABC12345678</strong>. Use this to track your application.
+  Updates will be sent to <b>name@example.com</b>.
+</p>
+              '
+            }
+        ]
+    }) }}
 
   <h3>Emphasis and idiomatic text</h3>
   <p>
     You can use <code>&lt;em&gt;</code> to emphasize text as one would do when speaking, or <code>&lt;i&gt;</code> to
     draw attention to mark idiomatic text, such as a name or a phrase that is not otherwise important. For example:
   </p>
-  {% set code %}
-    <p>
-      You <em>must</em> read some of the <i>National Institute for Health and Care Research</i>'s new research!
-    </p>
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+    {{ example({
+      'id': 'example-text-style-em-and-i',
+      'examples': [
+            {
+              'type': 'html',
+              'code': '
+<p>
+  You <em>must</em> read some of the <i>National Institute for Health and Care Research</i>\'s new research!
+</p>
+              '
+            }
+        ]
+    }) }}
 
   <h3>Links</h3>
   <p>
     Links are blue and underlined by default. If your link is at the end of a sentence or
     paragraph, make sure that the linked text does not include the full stop.
   </p>
-  {% set code %}
-    <p>
-      Now that your application has been submitted, you can <a href="#">view its progress</a>.
-    </p>
-  {% endset %}
-  {% include 'docs/partials/html-example.html' %}
+    {{ example({
+      'id': 'example-text-style-links',
+      'examples': [
+            {
+              'type': 'html',
+              'code': '
+<p>
+  Now that your application has been submitted, you can <a href="#">view its progress</a>.
+</p>
+              '
+            }
+        ]
+    }) }}
 
   <h3>Readability</h3>
   <p>

--- a/src/docs/www/style/typography/index.html
+++ b/src/docs/www/style/typography/index.html
@@ -1,3 +1,4 @@
+{% from 'docs/macros/component/example.html' import example %}
 {% set title="Typography" %}
 {% extends 'docs/partials/style-page.html' %}
 {% block stylePageContent %}

--- a/src/macros/component/accordion.html
+++ b/src/macros/component/accordion.html
@@ -1,7 +1,11 @@
 {#
+@typedef {object}  Item
+@property {string} header
+@property {string} body
+
 @macro accordion
-@param {Array<object>} items
-       An array of objects, each of which has `{string} header` and `{string} body` properties.
+@param {Array<Item>} items
+       An array of accordion items.
 @param {string} id
        The ID of the root HTML element.
 @param {boolean} [mutuallyExclusive=false]

--- a/src/macros/component/alert.html
+++ b/src/macros/component/alert.html
@@ -1,7 +1,7 @@
 {#
 @macro alert
 @param {string} type
-       One of "info", "success", "warning", or "danger".
+       One of `info`, `success`, `warning`, or `danger`.
 @param {string} body
        The alert's body content.
 #}

--- a/src/macros/component/button.html
+++ b/src/macros/component/button.html
@@ -3,13 +3,13 @@
 @param {string} label
        The human-readable button label.
 @param {boolean} [large=false]
-       Whether to display a large Search component.
-@param {boolean} [disabled]
-       Whether the button must be disabled. Defaults to FALSE.
-@param {boolean} [secondary]
-       Whether the button represents a secondary/non-default action. Defaults to FALSE.
-@param {boolean} [danger]
-       Whether the button represents a dangerous action. Defaults to FALSE.
+       Whether to display a large Button.
+@param {boolean} [disabled=false]
+       Whether the button must be disabled.
+@param {boolean} [secondary=false]
+       Whether the button represents a secondary/non-default action.
+@param {boolean} [danger=false]
+       Whether the button represents a dangerous action.
 #}
 {% macro button(options) %}
 <button

--- a/src/macros/component/explore.html
+++ b/src/macros/component/explore.html
@@ -1,19 +1,23 @@
 {#
+@typedef {object} Card
+@property {string} heading
+          The human-readable category heading.
+@property {Array<Link>} links
+          The card's navigation links.
+
+@typedef {object} Link
+@property {string} href
+          The link's `href` value.
+@property {string} label
+          The human-readable link label.
+
 @macro explore
-@param {object} first
-       Properties are:
-       - `{string} heading`
-         The human-readable category heading.
-       - `{Array<object>} links`
-         Item properties are:
-         - `{string} href`
-           The link's `href` value.
-         - `{string} label`
-           The human-readable link label.
-@param {object} middle
-       Identical to the `first` option.
-@param {object} last
-       Identical to the `first` option.
+@param {Card} first
+       The first card.
+@param {Card} middle
+       The middle card.
+@param {Card} last
+       The last card.
 #}
 {% macro explore(options) %}
 <section id="explore" class="bg-white">

--- a/src/macros/component/footer.html
+++ b/src/macros/component/footer.html
@@ -1,14 +1,25 @@
 {#
+@typedef {object} SocialMediaLink
+@property {string} href
+          The link's href value.
+@property {string} label
+          The human-readable link label.
+@property {Array<string>} [classes=[]]
+           An array of CSS classes for the link icon.
+
+@typedef {object} NavigationLink
+@property {string} href
+          The link's href value.
+@property {string} label
+          The human-readable link label.
+
 @macro footer
 @param {string|null} [body=null]
        The footer's main body content, if any.
-@param {Array<object>} [socialMediaLinks=[]]
-       The additional social media links to show. Each item is an object with `{string} href`, `{string} label`, and
-       `{Array<string>} [classes=[]]` properties, which are the link href and an array of CSS classes for the
-        icon respectively.
-@param {Array<object>} [navigationLinks=[]]
-       The additional navigation links to show. Each item is an object with `{string} href` and `{string} label`
-       properties.
+@param {Array<SocialMediaLink>} [socialMediaLinks=[]]
+       The additional social media links to show.
+@param {Array<NavigationLink>} [navigationLinks=[]]
+       The additional navigation links to show.
 #}
 {% macro footer(options) %}
 <footer id="main-footer">

--- a/src/macros/component/select-input.html
+++ b/src/macros/component/select-input.html
@@ -2,7 +2,7 @@
 @macro selectInput
 @param {string} label
        The human-readable input label.
-@param {Array<object>} options
+@param {object} options
        Keys are each option's value, and values are options' human-readable value labels.
 @param {string} [value]
        The value of the currently selected option.

--- a/src/macros/component/table.html
+++ b/src/macros/component/table.html
@@ -20,25 +20,23 @@
 {% endmacro %}
 
 {#
+@typedef {string} CellBody
+         The cell's body.
+
+@typedef {object} Cell
+@property {CellBody} body
+@property {boolean} [header=false]
+          Whether the cell is a header and should be rendered as a `<th>`. This is `true` for all table head cells.
+@property {string|null} [headerScope=null]
+          The [scope](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope) for this cell's `<th>` tag.
+
 @macro table
-@param {Array<Array<string|object>>} head
-       The rows in the table head. Items are `Array<string|object>`, of which each item is an `string|object`
-       representing a cell, either as a `string` for the cell's body, or as an `object` with the following properties:
-       - `{string} body`
-         The cell's body.
-       - `{string|null} [headerScope=null]`
-         The [scope](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope) for this cell's `<th>` tag.
-@param {Array<Array<string|object>>} body
-       The rows in the table body. Items are `Array<string|object>`, of which each item is an `string|object`
-       representing a cell, either as a `string` for the cell's body, or as an `object` with the following properties:
-       - `{string} body`
-         The cell's body.
-       - `{boolean} [header=false]`
-         Whether the cell is a header and should be rendered as a `<th>`.
-       - `{string|null} [headerScope=null]`
-         The [scope](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope) for this cell's `<th>` tag.
+@param {Array<Array<Cell|CellBody>} head
+       The rows in the table head.
+@param {Array<Array<Cell|CellBody>} body
+       The rows in the table body.
 @param {string|null} [caption=null]
-       The table caption.
+The table caption.
 #}
 {% macro table(options) %}
 {% filter safe %}


### PR DESCRIPTION
This makes the macro docs easier to read (than JSDoc), and it clearly documents components in terms of their macro arguments, showing exactly which variations are supported. This pattern can be used for React or Twig implementations in the future, allowing us to keep all code examples in one place.

How to review:
- Navigate to https://design-system-git-nunjucks-examples-nihruk.vercel.app/component/table
- Evaluate the **display** of the examples on the page. Each should show a table and the HTML and Nunjucks code to render that same table, as well as the Nunjucks macro's argument documentation.