### PR TITLE
Allow examples to be opened in a window of their own

### DIFF
--- a/src/docs/macros/component/example.html
+++ b/src/docs/macros/component/example.html
@@ -55,7 +55,12 @@
        {# Show a rendered HTML example, if one can be rendered. #}
        {% set renderableHtmlExample = renderableHtmlExamples | first %}
        {% if renderableHtmlExample is not undefined %}
-              <div class="example-html-render p-3">{{ renderableHtmlExample.code | safe }}</div>
+              <p class="example-html-render-new-window">
+                     <a href="{{ renderableHtmlExample.code | renderHtmlExample(options.id) }}">open this example in its own window</a>
+              </p>
+              <div class="example-html-render p-3">
+                     {{ renderableHtmlExample.code | safe }}
+              </div>
        {% endif %}
 
        {# Show all examples. #}

--- a/src/docs/scss/main.scss
+++ b/src/docs/scss/main.scss
@@ -24,6 +24,15 @@
   border-bottom: 2px solid $navy-20;
 }
 
+.example-html-render-new-window {
+  @extend .px-3;
+  @extend .py-1;
+  @extend .rounded-top;
+
+  background-color: $white;
+  border-bottom: 2px solid $navy-20;
+}
+
 .example-code {
   background-color: $grey-20;
   max-height: 20rem;

--- a/src/docs/templates/page-html-example.html
+++ b/src/docs/templates/page-html-example.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    {% include 'docs/partials/header/head.html' %}
+    <body class="bg-grey-10">
+        <div>
+            {{ html | safe }}
+        </div>
+    </body>
+    <script src="/design-system.bundle.js"></script>
+</html>

--- a/tests/macro-documentation.js
+++ b/tests/macro-documentation.js
@@ -1,9 +1,12 @@
 'use strict'
 
 const {globSync} = require('glob')
-const {getMacroJsDocForFilePath} = require("../src/docs/js/nunjucks")
+const {getMacroJsDocForFilePath} = require('../src/docs/js/nunjucks')
 
-globSync([
+
+for (const path of globSync([
     [__dirname, '..', 'src', 'macros', '**', '[!_]*.html'].join('/'),
     [__dirname, '..', 'src', 'docs', 'macros', '**', '[!_]*.html'].join('/'),
-]).forEach(getMacroJsDocForFilePath)
+])) {
+    getMacroJsDocForFilePath(path)
+}


### PR DESCRIPTION
This fixes https://github.com/nihruk/design-system/issues/121

## How to test
- Navigate to any page with an example, such as https://design-system-git-example-open-new-window-nihruk.vercel.app/component/footer
- Confirm the presence of the *open this example in its own window* link for each example, and that it correctly opens an identical version of the example in a separate window