### PR TITLE
adding emphasised heading information

### DIFF
--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -102,6 +102,15 @@ h2 {
   }
 }
 
+h2::after {
+  background: $coral;
+  content: '';
+  display: block;
+  height: 0.375rem;
+  margin: 0.5rem 0;
+  width: 3rem;
+}
+
 h3 {
   font-size: 1.375rem; // 22px
   line-height: 1.4545; // 32px
@@ -203,21 +212,4 @@ main {
 
 .list-group {
   margin-bottom: 1.5rem;
-}
-
-// Integrated classes
-
-.heading-underline {
-  &::after {
-    content: '';
-    display: block;
-    height: 0.375rem;
-    margin: 0.5rem 0;
-    position: absolute; // changed from relative to absolute
-    width: 3rem;
-  }
-
-  &--coral::after {
-    background: $coral;
-  }
 }

--- a/src/docs/www/style/text/index.html
+++ b/src/docs/www/style/text/index.html
@@ -150,6 +150,35 @@
     page. Style headings consistently to create a clear content structure throughout your service.
   </p>
 
+  <h3>Emphasised headings</h3>
+  <p>
+    You can add <code>class="heading-underline"</code> to a heading to add visual emphasis. This is used to signify importance, particularly for the first heading in a new section.
+  </p>
+  <p>
+    Colours are added with a second class. Available colours are: 
+    <ul>
+      <li>
+        Coral: <code>class="heading-underline--coral"</code>
+      </li>
+    </ul>
+  </p>
+  <p>Combine the base class with a colour class for an emphasised heading. For example:
+  </p>
+
+    {{ example({
+      'id': 'example-heading-emphasised',
+      'examples': [
+            {
+              'type': 'html',
+              'code': '
+              <h2 class="heading-underline heading-underline--coral">
+              Emphasised heading
+              </h2>
+              '
+            }
+        ]
+    }) }}
+
   <h2>Paragraph text</h2>
 
   <h3>Importance and attention</h3>

--- a/src/docs/www/style/text/index.html
+++ b/src/docs/www/style/text/index.html
@@ -156,13 +156,14 @@
   </p>
   <p>
     Colours are added with a second class. Available colours are: 
-    <ul>
-      <li>
-        Coral: <code>class="heading-underline--coral"</code>
-      </li>
-    </ul>
   </p>
-  <p>Combine the base class with a colour class for an emphasised heading. For example:
+  <ul>
+    <li>
+      Coral: <code>class="heading-underline--coral"</code>
+    </li>
+  </ul>
+  <p>
+    Combine the base class with a colour class for an emphasised heading. For example:
   </p>
 
     {{ example({

--- a/src/docs/www/style/text/index.html
+++ b/src/docs/www/style/text/index.html
@@ -152,27 +152,16 @@
 
   <h3>Emphasised headings</h3>
   <p>
-    You can add <code>class="heading-underline"</code> to a heading to add visual emphasis. This is used to signify importance, particularly for the first heading in a new section.
+    All <code>&lt;h2&gt;</code> elements are emphasised with a coral underline. This allows top level headings to be quickly and easily scanned. For example:
   </p>
-  <p>
-    Colours are added with a second class. Available colours are: 
-  </p>
-  <ul>
-    <li>
-      Coral: <code>class="heading-underline--coral"</code>
-    </li>
-  </ul>
-  <p>
-    Combine the base class with a colour class for an emphasised heading. For example:
-  </p>
-
+ 
     {{ example({
       'id': 'example-heading-emphasised',
       'examples': [
             {
               'type': 'html',
               'code': '
-              <h2 class="heading-underline heading-underline--coral">
+              <h2>
               Emphasised heading
               </h2>
               '


### PR DESCRIPTION
Added section to text page on using emphasised headings.

Note for future, these were created as two classes so that other colours could be added easily. However, we have yet to add more than one colour. If there is no intention to do so, it would be simpler to merge this into a single class in the future.