### PR TITLE
Remove the redundant link title from the Footer component's social media link icons

### DIFF
--- a/src/macros/component/footer.html
+++ b/src/macros/component/footer.html
@@ -68,7 +68,7 @@
                         }
                     ].concat(options.socialMediaLinks | default([])) %}
                         <li>
-                            <a href="{{ link.href }}" title="{{ link.label }}"><i class="{{ link.classes.join(' ') }}"><span class="visually-hidden">{{ link.label }}</span></i></a>
+                            <a href="{{ link.href }}"><i class="{{ link.classes.join(' ') }}"><span class="visually-hidden">{{ link.label }}</span></i></a>
                         </li>
                     {% endfor %}
                 </ul>


### PR DESCRIPTION
## How to test
- Compare the Wave results for [the current Footer](https://wave.webaim.org/report#/https://design-system.nihr.ac.uk/) and [this PR](https://wave.webaim.org/report#/https://design-system-git-remove-redundant-footer-social-580ee4-nihruk.vercel.app/)
- Confirm that this change is an improvement.