### PR TITLE
Default font size for tables

### DIFF
--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -166,7 +166,8 @@ p,
 code,
 kbd,
 pre,
-samp {
+samp,
+table {
   font-size: 1.125rem; // 18px
   line-height: 1.333; // 24px
   margin-bottom: 1.5rem; // 24px


### PR DESCRIPTION
Using the default font size of 22 / 18px for tables, rather than 16px