### PR TITLE
Fix a bug where the value of aria-current HTML attributes would be invalid

### DIFF
--- a/src/docs/js/nunjucks.js
+++ b/src/docs/js/nunjucks.js
@@ -277,12 +277,13 @@ class Environment extends nunjucks.Environment {
         this.addFilter('htmlAttributes', attributes => {
             let renderedAttributes = ' '
             for (let [name, value] of Object.entries(attributes)) {
-                if (typeof value !== 'string') {
+                if (value === null) {
+                    continue
+                }
+                if (typeof value !== 'string' && value) {
                     value = value.join(' ')
                 }
-                if (value) {
-                    renderedAttributes += ` ${name}="${value}"`
-                }
+                renderedAttributes += ` ${name}="${value}"`
             }
             return new SafeString(renderedAttributes.trimEnd())
         })

--- a/src/docs/partials/secondary-navigation.html
+++ b/src/docs/partials/secondary-navigation.html
@@ -1,14 +1,19 @@
 <h2 class="h4">{{ heading }}</h2>
 <ul class="nav nav-pills flex-column">
     {% for linkPath, linkLabel in links %}
+    {% set classes = ['nav-link', 'rounded-0'] %}
+    {% if (rootPath ~ linkPath) is activeCurrentUrl %}
+        {% set classes = classes.concat(['active']) %}
+        {% set ariaCurrent = 'page' %}
+    {% else %}
+        {% set ariaCurrent = null %}
+    {% endif %}
+    {% set linkAttributes = {
+        'class': classes,
+        'aria-current': ariaCurrent
+    } %}
         <li>
-            <a href="{{ rootPath }}{{ linkPath }}" class="nav-link rounded-0
-                {%- if (rootPath ~ linkPath) is activeCurrentUrl %}
-                    active" aria-current="page
-                {%- elif linkPath != '/' and (rootPath ~ linkPath) is activeParentUrl %}
-                    active
-                {% endif %}
-                ">
+            <a href="{{ rootPath }}{{ linkPath }}" {{ linkAttributes | htmlAttributes }}>
                 {{ linkLabel }}
             </a>
         </li>


### PR DESCRIPTION
The W3C HTML validator reports *Bad value `page               ` for attribute `aria-current` on element `a`* ([report](https://validator.w3.org/nu/?doc=https%3A%2F%2Fdesign-system.nihr.ac.uk%2Fstyle%2Fcolour))

This PR implements the newly introduced `htmlAttributes` filter (which now also accepts `null` for single-value attributes) to fix the rendering of the `aria-current` attribute.