### PR TITLE
Use the card() macro in Hero component examples

### DIFF
--- a/src/assets/scss/abstracts/variables/_card.scss
+++ b/src/assets/scss/abstracts/variables/_card.scss
@@ -9,7 +9,7 @@ $bs-card-border-width: 0;
     border-radius: 5px;
 }
 
-.card--blue {
+.card--navy {
     background: $navy!important;
     
     h1, h2, h3, h4, h5, h6, p, ul, ol, a {

--- a/src/docs/www/component/hero/index.html
+++ b/src/docs/www/component/hero/index.html
@@ -99,25 +99,18 @@
 
 {% set code %}
 {% raw %}
+{% from 'macros/component/card.html' import card %}
+{% set textCard = card({
+    'heading': 'Lorem ipsum',
+    'content': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce gravida odio enim, eget congue neque dignissim nec.',
+    'backgroundColor': 'navy'
+}) %}
+{% set imageCard = card({
+    'image': 'https://www.nihr.ac.uk/images/800-600/covid-nurses-hospital.jpg'
+}) %}
 {{ hero({
     'heroBackground': 'hero--coral',
-    'body': '
-        <div class="row gap-5">
-            <div class="col">
-                <div class="card h-100 card--blue">
-                    <div class="card-body d-flex flex-column">
-                        <h2 class="card-title h3 heading-underline heading-underline--coral">Card Title</h2>
-                        <p class="card-text">This is a card with supporting text below.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card h-100">
-                    <img src="https://www.nihr.ac.uk/images/800-600/covid-nurses-hospital.jpg" class="w-100" alt="">
-                </div>
-            </div>
-        </div>
-    ' | safe
+    'body': ('<div class="row">' ~ textCard ~ imageCard ~ '</div>') | safe
 }) }}
 {% endraw %}  
 {% endset %}
@@ -136,28 +129,20 @@
 
 {% set code %}
 {% raw %}
+{% from 'macros/component/card.html' import card %}
+{% set firstTextCard = card({
+    'heading': 'Lorem ipsum',
+    'content': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce gravida odio enim, eget congue neque dignissim nec.',
+    'backgroundColor': 'navy'
+}) %}
+{% set secondTextCard = card({
+    'heading': 'Donec lacinia',
+    'content': 'Donec lacinia faucibus sapien, in varius metus iaculis eget. Sed pellentesque libero in imperdiet elementum.',
+    'backgroundColor': 'navy'
+}) %}
 {{ hero({
     'heroBackground': 'hero--coral',
-    'body': '
-        <div class="row gap-5">
-            <div class="col">
-                <div class="card h-100 card--blue">
-                    <div class="card-body d-flex flex-column">
-                        <h2 class="card-title h3 heading-underline heading-underline--coral">Card Title</h2>
-                        <p class="card-text">This is a card with supporting text below.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card h-100 card--blue">
-                    <div class="card-body d-flex flex-column">
-                        <h2 class="card-title h3 heading-underline heading-underline--coral">Card Title</h2>
-                        <p class="card-text">This is another card with supporting text below.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    ' | safe
+    'body': ('<div class="row">' ~ firstTextCard ~ secondTextCard ~ '</div>') | safe
 }) }}
 {% endraw %} 
 {% endset %}
@@ -176,28 +161,18 @@
 
 {% set code %}
 {% raw %}
+{% from 'macros/component/card.html' import card %}
+{% set firstTextCard = card({
+    'heading': 'Lorem ipsum',
+    'content': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce gravida odio enim, eget congue neque dignissim nec.'
+}) %}
+{% set secondTextCard = card({
+    'heading': 'Donec lacinia',
+    'content': 'Donec lacinia faucibus sapien, in varius metus iaculis eget. Sed pellentesque libero in imperdiet elementum.'
+}) %}
 {{ hero({
     'heroBackground': 'hero--blue',
-    'body': '
-        <div class="row gap-5">
-            <div class="col">
-                <div class="card h-100 card--white">
-                    <div class="card-body d-flex flex-column">
-                        <h2 class="card-title h3 heading-underline heading-underline--coral">Card Title</h2>
-                        <p class="card-text">This is a card with supporting text below.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card h-100 card--white">
-                    <div class="card-body d-flex flex-column">
-                        <h2 class="card-title h3 heading-underline heading-underline--coral">Card Title</h2>
-                        <p class="card-text">This is another card with supporting text below.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    ' | safe
+    'body': ('<div class="row">' ~ firstTextCard ~ secondTextCard ~ '</div>') | safe
 }) }}
 {% endraw %} 
 {% endset %}
@@ -216,17 +191,13 @@
 
 {% set code %}
 {% raw %}
+{% from 'macros/component/card.html' import card %}
+{% set imageCard = card({
+    'image': 'https://www.nihr.ac.uk/images/news/head-up-collar.png'
+}) %}
 {{ hero({
     'heroBackground': 'hero--coral',
-    'body': '
-        <div class="row">
-            <div class="col">
-                <div class="card h-100">
-                    <img src="https://www.nihr.ac.uk/images/news/head-up-collar.png" class="w-100" alt="">
-                </div>
-            </div>
-        </div>
-    ' | safe
+    'body': ('<div class="row">' ~ imageCard ~ '</div>') | safe
 }) }}
 {% endraw %} 
 {% endset %}
@@ -245,22 +216,16 @@
 
 {% set code %}
 {% raw %}
+{% from 'macros/component/card.html' import card %}
+{% set firstImageCard = card({
+    'image': 'https://www.nihr.ac.uk/images/800-600/covid-nurses-hospital.jpg'
+}) %}
+{% set secondImageCard = card({
+    'image': 'https://www.nihr.ac.uk/images/800-600/covid-nurses-hospital.jpg'
+}) %}
 {{ hero({
     'heroBackground': 'hero--blue',
-    'body': '
-        <div class="row">
-            <div class="col">
-                <div class="card h-100">
-                    <img src="https://www.nihr.ac.uk/images/800-600/covid-nurses-hospital.jpg" class="w-100" alt="">
-                </div>
-            </div>
-            <div class="col">
-                <div class="card h-100">
-                    <img src="https://www.nihr.ac.uk/images/800-600/covid-nurses-hospital.jpg" class="w-100" alt="">
-                </div>
-            </div>
-        </div>
-    ' | safe
+    'body': ('<div class="row">' ~ firstImageCard ~ secondImageCard ~ '</div>') | safe
 }) }}
 {% endraw %} 
 {% endset %}

--- a/src/macros/component/card.html
+++ b/src/macros/component/card.html
@@ -2,23 +2,37 @@
     @macro card
     @param {string|null=null} heading
           The human-readable card heading.
-    @param {string} content
+    @param {string|null=null} content
           The human-readable content of the card.
     @param {string|null} [image=null]
           Any image's src attribute value.
+    @param {'white'|'navy'} [backgroundColor='white']
+          The card's background color.
 #}
 {% macro card(options) %}
-    <div class="col-md">
-    <div class="card h-100">
+<div class="col-md">
+    <div class="card h-100 {% if options.backgroundColor | default('white') == 'navy' %}card--navy{% endif %}">
         {% if options.image | default(null) %}
-        <img src="{{ options.image }}" class="card-img-top" alt="">
-        {% endif %}
-        <div class="card-body d-flex flex-column">
-            {% if options.heading is defined %}
-                <h2 class="card-title h3 heading-underline heading-underline--coral">{{ options.heading }}</h2>
+        <img
+            src="{{ options.image }}"
+            {% if options.heading or options.content %}
+                class="card-img-top"
+            {% else %}
+                class="card-img"
             {% endif %}
-            <p class="card-text">{{ options.content }}</p>
-        </div>
+            alt=""
+        >
+        {% endif %}
+        {% if options.heading or options.content %}
+            <div class="card-body d-flex flex-column">
+                {% if options.heading %}
+                    <h2 class="card-title h3 heading-underline heading-underline--coral">{{ options.heading }}</h2>
+                {% endif %}
+                {% if options.content %}
+                    <p class="card-text">{{ options.content }}</p>
+                {% endif %}
+            </div>
+        {% endif %}
     </div>
-    </div>
+</div>
 {% endmacro %} 

--- a/src/macros/component/hero.html
+++ b/src/macros/component/hero.html
@@ -8,7 +8,7 @@
 {% macro hero(options) %}
     <section class="hero {{ options.heroBackground }}" aria-description="hero section">
         <div class="container">    
-            {% if options.body is defined %}
+            {% if options.body %}
                 {{ options.body }}
             {% endif %}
         </div>


### PR DESCRIPTION
## Definition of Done
- Ensure that the Hero component documentation page uses the `card()` Nunjucks macro to render example cards, instead of including raw hardcoded card HTML.

## How to test
- Evaluate https://design-system-git-use-card-macro-in-hero-examples-nihruk.vercel.app/component/hero