### PR TITLE
Fix a grid bug on the All colours page

### DIFF
--- a/src/docs/www/style/colour/all-colours/index.html
+++ b/src/docs/www/style/colour/all-colours/index.html
@@ -1,12 +1,22 @@
 {% from 'docs/macros/component/colour-specification.html' import colourSpecification %}
+{% from 'macros/component/callout-text.html' import calloutText %}
 {% set pageTitle = 'All colours' %}
 {% extends 'docs/partials/page.html' %}
 
 {% block pageContent %}
+<div class="container">
   <div class="row">
-    <p>
-      <a href="/style/colour">Back to Colour</a>
-    </p>
+    <div class="col-8">
+      {{ calloutText({
+          'paragraphs': [
+              {
+                  'body': '<a href="/style/colour">Back to Colours</a>' | safe
+              }
+          ]
+      }) }}
+    </div>
+  </div>
+  <div class="row">
     {% for colour in _colours %}
       <section class="col-md-6 col-xl-4">
         <h2>NIHR {{ colour.label }}</h2>
@@ -24,4 +34,5 @@
       </section>
     {% endfor %}
   </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
Fix a grid bug on the All colours page that would not leave any whitespace around the content. See https://design-system.nihr.ac.uk/style/colour/all-colours.

## How to test
- Evaluate https://design-system-git-fix-all-colours-page-nihruk.vercel.app/style/colour/all-colours