### PR TITLE
Fix the documentation site title

### DIFF
--- a/src/docs/partials/page.html
+++ b/src/docs/partials/page.html
@@ -32,7 +32,7 @@
     ],
     'pageContent': pageContent | safe,
     'header': {
-        'serviceTitle': 'Design System for the NIHR'
+        'serviceTitle': 'Design System'
     },
     'footer': {
         'socialMediaLinks': [

--- a/src/docs/www/index.html
+++ b/src/docs/www/index.html
@@ -1,5 +1,5 @@
 {% from 'macros/component/action-link.html' import actionLink %}
-{% set pageTitle = 'Design System' %}
+{% set pageTitle = 'Design System for the NIHR' %}
 {% extends 'docs/partials/page.html' %}
 {% block pageContent %}
 

--- a/src/macros/component/page.html
+++ b/src/macros/component/page.html
@@ -29,7 +29,7 @@ The human-readable link label.
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% if options.pageTitle is defined %}{{ options.pageTitle }} - {% endif %}{{ options.siteTitle }}</title>
+  <title>{% if options.pageTitle is defined and options.pageTitle != options.siteTitle %}{{ options.pageTitle }} - {% endif %}{{ options.siteTitle }}</title>
   <link rel="shortcut icon" href="https://www.nihr.ac.uk/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="/design-system.bundle.css">
   <link rel="stylesheet" href="/docs.bundle.css">


### PR DESCRIPTION
The front page's HTML title was *Design System for the NIHR - Design System for the NIHR*, which is duplicate.

## Changes
- The front page's HTML title is now *Design System for the NIHR*
- The front page's `<h1>` is now *Design System for the NIHR*
- The service title is now *Design System*
