### PR TITLE
Fix layout spacing bugs

### DIFF
--- a/src/assets/scss/components/_hero.scss
+++ b/src/assets/scss/components/_hero.scss
@@ -1,5 +1,5 @@
 .hero {
-    padding: 2rem 1.25rem;
+    padding: 1.25rem 0;
 }
 
 .hero--blue {

--- a/src/docs/partials/component-page.html
+++ b/src/docs/partials/component-page.html
@@ -1,18 +1,18 @@
 {% extends 'docs/partials/page.html' %}
 {% block pageContent %}
-<div class="container pt-5">
+<div class="container">
     <div class="row">
         <h1>{{ pageTitle }}</h1>
-      <nav class="col-lg-4 d-none d-lg-block">
-        {% include 'docs/partials/component-navigation.html' %}
-      </nav>
-      <div class="col-lg-8">
-        {% block componentPageContent %}
-        {% endblock %}
-      </div>
-      <nav class="col d-lg-none">
-        {% include 'docs/partials/component-navigation.html' %}
-      </nav>
+        <nav class="col-lg-4 d-none d-lg-block">
+            {% include 'docs/partials/component-navigation.html' %}
+        </nav>
+        <div class="col-lg-8">
+            {% block componentPageContent %}
+            {% endblock %}
+        </div>
+        <nav class="col d-lg-none">
+            {% include 'docs/partials/component-navigation.html' %}
+        </nav>
     </div>
 </div>
 {% endblock %}

--- a/src/docs/partials/get-started-page.html
+++ b/src/docs/partials/get-started-page.html
@@ -1,6 +1,6 @@
 {% extends 'docs/partials/page.html' %}
 {% block pageContent %}
-<div class="container pt-5">
+<div class="container">
     <div class="row">
       <h1>{{ pageTitle }}</h1>
       <nav class="col-lg-4 d-none d-lg-block">

--- a/src/docs/partials/style-page.html
+++ b/src/docs/partials/style-page.html
@@ -1,6 +1,6 @@
 {% extends 'docs/partials/page.html' %}
 {% block pageContent %}
-<div class="container pt-5">
+<div class="container">
     <div class="row">
       <h1>{{ pageTitle }}</h1>
       <nav class="col-lg-4 d-none d-lg-block">

--- a/src/docs/www/about-us/index.html
+++ b/src/docs/www/about-us/index.html
@@ -1,7 +1,7 @@
 {% set pageTitle = 'About us' %}
 {% extends 'docs/partials/page.html' %}
 {% block pageContent %}
-<div class="container pt-5">
+<div class="container">
     <div class="row">
         <div class="col-lg-8">
             <h1>{{ pageTitle }}</h1>

--- a/src/docs/www/accessibility/index.html
+++ b/src/docs/www/accessibility/index.html
@@ -2,7 +2,7 @@
 {% set pageTitle = 'Accessibility' %}
 {% extends 'docs/partials/page.html' %}
 {% block pageContent %}
-<div class="container pt-5">
+<div class="container">
     <div class="row">
         <h1>{{ pageTitle }}</h1>
         <div class="col-lg-8">

--- a/src/docs/www/component/page/index.html
+++ b/src/docs/www/component/page/index.html
@@ -15,7 +15,7 @@
     'siteTitle': 'Lorem ipsum',
     'pageContent': '
 <div class="container">
-        <div class="row">
+    <div class="row">
         <div class="col-8">
             <h1>Lorem ipsum dolor sit amet</h1>
             <p>

--- a/src/docs/www/index.html
+++ b/src/docs/www/index.html
@@ -5,42 +5,40 @@
 {% extends 'docs/partials/page.html' %}
 {% block pageContent %}
 
-<section>
-    {% set heroBody %}
-    <div class="row">
-        <div class="col-lg-8">
-            <h1 class="text-white">{{ pageTitle }}</h1>
-            <p class="lead text-white">
-                Design and build web applications for the <a href="https://nihr.ac.uk" class="text-white">NIHR</a> that are
-                <strong>accessible</strong>, <strong>user-friendly</strong>, and provide consistent
-                <strong>user journeys</strong>.
-            </p>
-        </div>
-        <div class="col-lg-4">
-            {% set cardBody %}
-            {{ actionLink({
-                'href': '/get-started',
-                'text': 'Get started',
-                'title': 'Get started with the Design System'
-            }) }}
-            <p class="mb-0">
-                or run <span class="d-block"><code
-                    class="user-select-all">npm install @nihruk/design-system</code></span>
-            </p>
-            {% endset %}
-            {{ card({
-                'body': cardBody | safe
-            }) }}
-        </div>
+{% set heroBody %}
+<div class="row">
+    <div class="col-lg-8">
+        <h1 class="text-white">{{ pageTitle }}</h1>
+        <p class="lead text-white">
+            Design and build web applications for the <a href="https://nihr.ac.uk" class="text-white">NIHR</a> that are
+            <strong>accessible</strong>, <strong>user-friendly</strong>, and provide consistent
+            <strong>user journeys</strong>.
+        </p>
     </div>
-    {% endset %}
-    {{ hero({
-        'body': heroBody | safe
-    }) }}
-</section>
+    <div class="col-lg-4">
+        {% set cardBody %}
+        {{ actionLink({
+            'href': '/get-started',
+            'text': 'Get started',
+            'title': 'Get started with the Design System'
+        }) }}
+        <p class="mb-0">
+            or run <span class="d-block"><code
+                class="user-select-all">npm install @nihruk/design-system</code></span>
+        </p>
+        {% endset %}
+        {{ card({
+            'body': cardBody | safe
+        }) }}
+    </div>
+</div>
+{% endset %}
+{{ hero({
+    'body': heroBody | safe
+}) }}
 <section class="mt-5">
     <div class="container">
-        <div class="row mt-5">
+        <div class="row">
             <div class="col-lg-4">
                 <h2 class="heading-underline">Styles</h2>
                 <p>

--- a/src/macros/component/page.html
+++ b/src/macros/component/page.html
@@ -61,8 +61,8 @@ The human-readable link label.
     </div>
 </nav>
 
-<main class="pt-0">
-{{ options.pageContent }}
+<main>
+    {{ options.pageContent }}
 </main>
 {{ footer(options.footer | default({})) }}
 </body>


### PR DESCRIPTION
The main API change is that a Hero no longer contains any horizontal padding, to fully allow developers to arrange their own layout.

This also ensures that any page has a gap of 5 Bootstraps between the primary navigation and the first content on the page, regardless of whether that is a heading, or a Hero.