### PR TITLE
Fix a bug where the distribution files could not be used on all websites

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,16 +153,14 @@ module.exports = (env, args) => {
           test: /\.(png|gif|jpg|jpeg)$/,
           type: 'asset/resource',
           generator: {
-            outputPath: path.join('assets', 'images'),
+            filename: 'assets/images/[name][ext]',
           }
         },
         {
           test: /\.(ttf|woff2?)$/,
           type: 'asset/resource',
           generator: {
-            outputPath: path.join('assets', 'fonts'),
-            publicPath: 'assets/fonts/',
-            filename: '[name][ext]',
+            filename: 'assets/fonts/[name][ext]',
           }
         }
       ]


### PR DESCRIPTION
Fix a bug where the distribution files could not be used on all websites because assets were referenced root-relatively.

This fixes https://github.com/nihruk/design-system/issues/158

## How to test
- Confirm that view-source:https://design-system-git-fix-webpack-asset-path-nihruk.vercel.app/design-system.bundle.css contains fully relative paths such as `url(assets/fonts/lato-latin-ext-300-normal.woff2)` instead of `url(/assets/fonts/lato-latin-ext-300-normal.woff2)` (which is the old, root-relative situation)
- Evaluate that https://design-system-git-fix-webpack-asset-path-nihruk.vercel.app/ shows the Lato font and Font Awesome icons.