### PR TITLE
Rename the Search Input to Search Form

### DIFF
--- a/src/assets/scss/components/_components.scss
+++ b/src/assets/scss/components/_components.scss
@@ -1,7 +1,7 @@
 @import './accordion';
 @import './main-header';
 @import './main-navigation';
-@import './search-component';
+@import './search-form';
 @import './footer';
 @import './action-link';
 @import './callout-text';

--- a/src/assets/scss/components/_main-header.scss
+++ b/src/assets/scss/components/_main-header.scss
@@ -5,7 +5,7 @@
     }
   }
 
-  .search-component {
+  .search-form {
     margin: 1rem 0 0;
 
     @include media-breakpoint-up(md) {

--- a/src/assets/scss/components/_search-form.scss
+++ b/src/assets/scss/components/_search-form.scss
@@ -1,4 +1,4 @@
-.search-component {
+.search-form {
   .input-group-lg {
     .form-control {
       height: 4rem !important;

--- a/src/docs/partials/component-navigation.html
+++ b/src/docs/partials/component-navigation.html
@@ -11,7 +11,7 @@
     '/header': 'Header',
     '/hero': 'Hero',
     '/page': 'Page',
-    '/search': 'Search',
+    '/search-form': 'Search Form',
     '/select-input': 'Select Input',
     '/table': 'Table',
     '/text-input': 'Text input'

--- a/src/docs/www/component/header/index.html
+++ b/src/docs/www/component/header/index.html
@@ -10,7 +10,7 @@
 <h2 class="heading-underline">Intended behaviour</h2>
 
 <p>
-    The header consists of the NIHR logo and an optional <a href="/component/search">Search component</a>. The logo
+    The header consists of the NIHR logo and an optional <a href="/component/search-form">Search Form</a>. The logo
     is also a link back to the current site's front page. Entering a search query will return results.
 </p>
 
@@ -39,11 +39,11 @@
   ]
 }) }}
 
-<h3>Header with search</h3>
+<h3>Header with Search Form</h3>
 {% set code %}
 {% raw %}
 {{ header({
-  'search': {
+  'searchForm': {
     'action': '#'
   }
 }) }}
@@ -65,7 +65,7 @@
 {% raw %}
 {{ header({
   'serviceTitle': 'Funding and Awards',
-  'search': {
+  'searchForm': {
     'action': '#'
   }
 }) }}

--- a/src/docs/www/component/search-form/index.html
+++ b/src/docs/www/component/search-form/index.html
@@ -1,10 +1,10 @@
-{% from 'macros/component/search.html' import search %}
+{% from 'macros/component/search-form.html' import searchForm %}
 {% from 'docs/macros/component/example.html' import example %}
-{% set pageTitle = 'Search' %}
+{% set pageTitle = 'Search Form' %}
 {% extends 'docs/partials/component-page.html' %}
 {% block componentPageContent %}
     <p class="lead">
-        Allow users to search for content by entering keywords.
+        The Search Form is an entrypoint into a search service by allowing users to enter keywords.
     </p>
 
     <h2 class="heading-underline">Variations</h2>
@@ -13,7 +13,7 @@
 
     {% set code %}
 {% raw %}
-{{ search({
+{{ searchForm({
     'action': '#'
 }) }}
 {% endraw %}
@@ -23,7 +23,7 @@
       'examples': [
           {
               'type': 'nunjucks',
-              'nunjucksMacro': 'component/search',
+              'nunjucksMacro': 'component/search-form',
               'code': code
           }
       ]
@@ -33,7 +33,7 @@
 
     {% set code %}
 {% raw %}
-{{ search({
+{{ searchForm({
     'action': '#',
     'large': true
 }) }}
@@ -44,7 +44,7 @@
       'examples': [
           {
               'type': 'nunjucks',
-              'nunjucksMacro': 'component/search',
+              'nunjucksMacro': 'component/search-form',
               'code': code
           }
       ]

--- a/src/macros/component/header.html
+++ b/src/macros/component/header.html
@@ -1,8 +1,8 @@
-{% from 'macros/component/search.html' import search %}
+{% from 'macros/component/search-form.html' import searchForm %}
 {#
 @macro header
-@param {object|null} [search=null]
-       The arguments to the Search component.
+@param {object|null} [searchForm=null]
+       The arguments to the Search Form component.
 @param {string|null} [serviceTitle=null]
        The title of the service site.  
 #}
@@ -16,9 +16,9 @@
                       alt="The NIHR logo">
                 </a>
             </div>
-            {% if options.search | default(null) %}
+            {% if options.searchForm | default(null) %}
               <div class="col-md-4">
-                  {{ search(options.search) }}
+                  {{ searchForm(options.searchForm) }}
               </div>
             {% endif %}
         </div>

--- a/src/macros/component/search-form.html
+++ b/src/macros/component/search-form.html
@@ -1,12 +1,12 @@
 {#
-@macro search
+@macro searchForm
 @param {string} action
        The form's action href.
 @param {boolean} [large=false]
        Whether to display a large Search component.
 #}
-{% macro search(options) %}
-<form class="search-component" action="{{ options.action }}">
+{% macro searchForm(options) %}
+<form class="search-form" action="{{ options.action }}">
   <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
     <div class="input-group{% if options.large | default(false) %} input-group-lg{% endif %}">
       <input type="text" class="form-control" placeholder="Search" value="" aria-label="Search">


### PR DESCRIPTION
Rename the Search Input to Search Form, because it is in fact a stand-alone form.