### PR TITLE
Updated select input macros component

### DIFF
--- a/src/macros/component/select-input.html
+++ b/src/macros/component/select-input.html
@@ -19,6 +19,7 @@
 {% set id = options.id | default(generateId()) %}
 <label for="{{ id }}" class="form-label">{{ options.label }}</label>
 <select
+        id="{{ id }}"
         class="form-select{% if options.invalid | default(false) %} is-invalid{% endif %}"
         aria-label="{{ options.label }}"
         {% if options.required | default(false) %}required{% endif %}


### PR DESCRIPTION
#195 issue - The Select Input form label is not associated with its element 

fixed issue https://wave.webaim.org/report#/https://design-system-grwwhjzvm-nihruk.vercel.app/component/select-input