### PR TITLE
Allow components' HTML heading levels to be configured

### DIFF
--- a/src/macros/component/accordion.html
+++ b/src/macros/component/accordion.html
@@ -10,12 +10,15 @@
        The ID of the component's root HTML element.
 @param {boolean} [mutuallyExclusive=false]
        Whether only one item can be shown at a time.
+@param {int} [headingLevel=2]
+       The `<hX>` heading to use, where the value is one of `2`, `3`, `4`, `5`, or `6`.
 #}
 {% macro accordion(options) %}
+{% set headingLevel = headingLevel | default(2) %}
 <div class="accordion" id="{{ options.id }}">
   {% for item in options.items %}
     <div class="accordion-item">
-      <h2 class="accordion-header" id="panel-heading--{{ options.id }}--{{ loop.index }}">
+      <h{{ headingLevel }} class="accordion-header" id="panel-heading--{{ options.id }}--{{ loop.index }}">
         <button
           class="accordion-button{% if not item.show %} collapsed{% endif %}"
           type="button"
@@ -26,7 +29,7 @@
         >
           {{ item.header }}
         </button>
-      </h2>
+      </h{{ headingLevel }}>
       <div
         id="panel-collapse--{{ options.id }}--{{ loop.index }}"
         class="accordion-collapse collapse{% if item.show | default(false) %} show{% endif %}"

--- a/src/macros/component/card.html
+++ b/src/macros/component/card.html
@@ -1,15 +1,18 @@
 {#
-    @macro card
-    @param {string|null=null} heading
-          The human-readable card heading.
-    @param {string|null=null} body
-          The Card's HTML body.
-    @param {string|null} [image=null]
-          Any image's src attribute value.
-    @param {'white'|'navy'} [backgroundColor='white']
-          The card's background color.
+@macro card
+@param {string|null=null} heading
+      The human-readable card heading.
+@param {int} [headingLevel=2]
+       The `<hX>` heading to use, where the value is one of `2`, `3`, `4`, `5`, or `6`.
+@param {string|null=null} body
+      The Card's HTML body.
+@param {string|null} [image=null]
+      Any image's src attribute value.
+@param {'white'|'navy'} [backgroundColor='white']
+      The card's background color.
 #}
 {% macro card(options) %}
+{% set headingLevel = headingLevel | default(2) %}
 <div class="col-md">
     <div class="card h-100 {% if options.backgroundColor | default('white') == 'navy' %}card--navy{% endif %}">
         {% if options.image | default(null) %}
@@ -26,7 +29,7 @@
         {% if options.heading or options.body %}
             <div class="card-body d-flex flex-column">
                 {% if options.heading %}
-                    <h2 class="card-title h3 heading-underline">{{ options.heading }}</h2>
+                    <h{{ headingLevel }} class="card-title h3 heading-underline">{{ options.heading }}</h{{ headingLevel }}>
                 {% endif %}
                 {% if options.body %}
                     <div class="card-text">{{ options.body }}</div>


### PR DESCRIPTION
## How to test
- Evaluate https://design-system-git-heading-level-nihruk.vercel.app/component/accordion
- Evaluate https://design-system-git-heading-level-nihruk.vercel.app/component/card
- For both components, confirm the newly introduced `headingLevel` option is documented, and renders as a `<h2>` by default (original behavior)

## BC breaks
- None