### PR TITLE
Fix empty HTML attributes being rendered needlessly by the Nunjucks environment

### DIFF
--- a/src/assets/js/nunjucks.js
+++ b/src/assets/js/nunjucks.js
@@ -21,14 +21,29 @@ class Environment extends stdNunjucks.Environment {
         this._lastGeneratedId = 0
         this._currentPageUrlPath = null;
         this.addGlobal('generateId', () => environment.generateId())
+        const filterHtmlAttributeValue = (value) => {
+            if (value === null) {
+                return false
+            }
+            if (typeof value !== 'string') {
+                return false
+            }
+            if (value.trim() === '') {
+                return false
+            }
+            return true
+        }
         this.addFilter('htmlAttributes', attributes => {
             let renderedAttributes = ' '
             for (let [name, value] of Object.entries(attributes)) {
-                if (value === null) {
-                    continue
-                }
-                if (typeof value !== 'string' && value) {
-                    value = value.join(' ')
+                if (!filterHtmlAttributeValue(value)) {
+                    if (!Array.isArray(value)) {
+                        continue
+                    }
+                    value = value.filter(filterHtmlAttributeValue).join(' ')
+                    if (!value) {
+                        continue
+                    }
                 }
                 renderedAttributes += ` ${name}="${value}"`
             }


### PR DESCRIPTION
Our custom `htmlAttributes` Nunjucks filter occasionally renders empty HTML attributes when those attributes are in fact not needed (which is why they are empty).

## How to test
- Confirm that https://design-system.nihr.ac.uk/component/table shows empty attributes in the code examples, such as `<tr class="">`.
- Confirm that https://design-system-git-fix-empty-html-attributes-nihruk.vercel.app/component/table does not show these empty attributes