### PR TITLE
Active nav link and focus state harmonisation

### DIFF
--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -3,8 +3,13 @@
     padding: 0;
 
     .nav-item {
+      height: 4.375rem;
       padding: 1.25rem 1rem;
+  
+    &:has(.nav-link.active) {
+      border-bottom: 4px solid $navy;
     }
+    }  
 
     .nav-link {
       color: $navy;
@@ -16,7 +21,6 @@
       font-size: $font-size-lg;
       }
 
-      &.active,
       &:hover {
         color: $navy;
         text-decoration: underline;
@@ -30,6 +34,10 @@
         outline: 3px solid transparent;
         text-decoration: none;
         transition: 0s;
+      }
+
+      &:not(:hover):not(:active) {
+        text-decoration: none;
       }
     }
   }

--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -22,13 +22,10 @@
       font-size: $font-size-lg;
       }
 
-      &:after {
+      &::after {
         content: "";
         position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
+        inset: 0;
       }
 
       &:hover {
@@ -51,7 +48,7 @@
       }
     }
 
-    .nav-link.active:after {
+    .nav-link.active::after {
       box-shadow: inset 0 -4px $navy;
     }
   }

--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -5,6 +5,10 @@
     .nav-item {
       height: 4.375rem;
       padding: 1.25rem 1rem;
+
+    &:first-child {
+      padding: 1.25rem 1rem 1.25rem 0;
+    }  
   
     &:has(.nav-link.active) {
       border-bottom: 4px solid $navy;

--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -10,10 +10,6 @@
     &:first-child {
       padding: 1.25rem 1rem 1.25rem 0;
     }  
-  
-    /*&:has(.nav-link.active) {
-      border-bottom: 4px solid $navy;
-    }*/
   }  
 
     .nav-link {

--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -30,7 +30,7 @@
         text-decoration: underline;
         text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
       }
-      
+    
       &:focus {
         background-color: $interaction-focus;
         box-shadow: 0 0 #fed47a, inset 0 -4px $black;
@@ -38,10 +38,10 @@
         outline: 3px solid transparent;
         text-decoration: none;
         transition: 0s;
-      }
 
-      &:not(:hover) {
-        text-decoration: none;
+        &:not(:hover) {
+          text-decoration: none;
+        }
       }
     }
   }

--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -2,11 +2,15 @@
   @include media-breakpoint-up(lg) {
     padding: 0;
 
-    .nav-link {
+    .nav-item {
       padding: 1.25rem 1rem;
+    }
+
+    .nav-link {
+      color: $navy;
       font-size: $font-size-sm;
       font-weight: bold;
-      color: $navy;
+      padding: 0;
 
       @include media-breakpoint-up(lg) {
       font-size: $font-size-lg;
@@ -14,8 +18,9 @@
 
       &.active,
       &:hover {
-        background-color: $navy;
-        color: #fff;
+        color: $navy;
+        text-decoration: underline;
+        text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
       }
       
       &:focus {

--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -11,10 +11,10 @@
       padding: 1.25rem 1rem 1.25rem 0;
     }  
   
-    &:has(.nav-link.active) {
+    /*&:has(.nav-link.active) {
       border-bottom: 4px solid $navy;
-    }
-    }  
+    }*/
+  }  
 
     .nav-link {
       color: $navy;
@@ -53,6 +53,10 @@
           text-decoration: none;
         }
       }
+    }
+
+    .nav-link.active:after {
+      box-shadow: inset 0 -4px $navy;
     }
   }
 }

--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -40,7 +40,7 @@
         transition: 0s;
       }
 
-      &:not(:hover):not(:active) {
+      &:not(:hover) {
         text-decoration: none;
       }
     }

--- a/src/assets/scss/components/_main-navigation.scss
+++ b/src/assets/scss/components/_main-navigation.scss
@@ -5,6 +5,7 @@
     .nav-item {
       height: 4.375rem;
       padding: 1.25rem 1rem;
+      position: relative;
 
     &:first-child {
       padding: 1.25rem 1rem 1.25rem 0;
@@ -23,6 +24,15 @@
 
       @include media-breakpoint-up(lg) {
       font-size: $font-size-lg;
+      }
+
+      &:after {
+        content: "";
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
       }
 
       &:hover {

--- a/src/assets/scss/components/_secondary-navigation.scss
+++ b/src/assets/scss/components/_secondary-navigation.scss
@@ -17,6 +17,11 @@
       color: inherit;
     }
 
+    .nav-link:hover {
+      text-decoration: underline;
+      text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+    }
+
     .nav-link:focus {
       background-color: $interaction-focus;
       box-shadow: 0 0 $interaction-focus, inset 0 -4px $black;
@@ -24,11 +29,10 @@
       outline: 3px solid transparent;
       text-decoration: none;
       transition: 0s;
-    }
 
-    .nav-link:hover {
-      text-decoration: underline;
-      text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+      &:not(:hover) {
+        text-decoration: none;
+      }
     }
   }
 }

--- a/src/assets/scss/components/_secondary-navigation.scss
+++ b/src/assets/scss/components/_secondary-navigation.scss
@@ -6,40 +6,39 @@
     .nav-link {
       display: inline-flex;
       padding: 0;
-    }
 
-    .nav-link.active, 
-    .show>.nav-link {
-      background-color: inherit;
-      color: $navy;
+      &.active {
+        background-color: inherit;
+        color: $navy;
+      }
+
+      &::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+      }
+  
+      &:hover {
+        text-decoration: underline;
+        text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+      }
+  
+      &:focus {
+        background-color: $interaction-focus;
+        box-shadow: 0 0 $interaction-focus, inset 0 -4px $black;
+        color: $black;
+        outline: 3px solid transparent;
+        text-decoration: none;
+        transition: 0s;
+  
+        &:not(:hover) {
+          text-decoration: none;
+        }
+      }
     }
 
     .nav-link.active::after {
       box-shadow: inset 4px 0 0 0 #193e72;
-    }
-
-    .nav-link::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-    }
-
-    .nav-link:hover {
-      text-decoration: underline;
-      text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
-    }
-
-    .nav-link:focus {
-      background-color: $interaction-focus;
-      box-shadow: 0 0 $interaction-focus, inset 0 -4px $black;
-      color: $black;
-      outline: 3px solid transparent;
-      text-decoration: none;
-      transition: 0s;
-
-      &:not(:hover) {
-        text-decoration: none;
-      }
     }
   }
 }

--- a/src/assets/scss/components/_secondary-navigation.scss
+++ b/src/assets/scss/components/_secondary-navigation.scss
@@ -14,17 +14,14 @@
       color: $navy;
     }
 
-    .nav-link.active:after {
-      box-shadow: inset 4px 0px 0px 0px #193e72;
+    .nav-link.active::after {
+      box-shadow: inset 4px 0 0 0 #193e72;
     }
 
-    .nav-link:after {
+    .nav-link::after {
       content: "";
       position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
+      inset: 0;
     }
 
     .nav-link:hover {

--- a/src/assets/scss/components/_secondary-navigation.scss
+++ b/src/assets/scss/components/_secondary-navigation.scss
@@ -1,8 +1,30 @@
-.nav-pills .nav-link:focus {
-    background-color: $interaction-focus;
-    box-shadow: 0 0 $interaction-focus, inset 0 -4px $black;
-    color: $black;
-    outline: 3px solid transparent;
-    text-decoration: none;
-    transition: 0s;
+#secondary-navigation {
+
+  li {
+    padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
+
+    &:has(.nav-link.active) {
+      border-left: 4px solid $navy;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      padding: 0;
+    }
+
+    .nav-link.active, 
+    .show>.nav-link {
+      background-color: inherit;
+      color: inherit;
+    }
+
+    .nav-link:focus {
+      background-color: $interaction-focus;
+      box-shadow: 0 0 $interaction-focus, inset 0 -4px $black;
+      color: $black;
+      outline: 3px solid transparent;
+      text-decoration: none;
+      transition: 0s;
+    }
   }
+}

--- a/src/assets/scss/components/_secondary-navigation.scss
+++ b/src/assets/scss/components/_secondary-navigation.scss
@@ -1,5 +1,4 @@
-#secondary-navigation {
-
+.secondary-navigation {
   li {
     padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
 

--- a/src/assets/scss/components/_secondary-navigation.scss
+++ b/src/assets/scss/components/_secondary-navigation.scss
@@ -25,5 +25,10 @@
       text-decoration: none;
       transition: 0s;
     }
+
+    .nav-link:hover {
+      text-decoration: underline;
+      text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+    }
   }
 }

--- a/src/assets/scss/components/_secondary-navigation.scss
+++ b/src/assets/scss/components/_secondary-navigation.scss
@@ -1,10 +1,7 @@
 .secondary-navigation {
   li {
     padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
-
-    &:has(.nav-link.active) {
-      border-left: 4px solid $navy;
-    }
+    position: relative;
 
     .nav-link {
       display: inline-flex;
@@ -14,7 +11,20 @@
     .nav-link.active, 
     .show>.nav-link {
       background-color: inherit;
-      color: inherit;
+      color: $navy;
+    }
+
+    .nav-link.active:after {
+      box-shadow: inset 4px 0px 0px 0px #193e72;
+    }
+
+    .nav-link:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
     }
 
     .nav-link:hover {

--- a/src/docs/partials/secondary-navigation.html
+++ b/src/docs/partials/secondary-navigation.html
@@ -1,4 +1,4 @@
-<ul class="nav nav-pills flex-column" id="secondary-navigation">
+<ul class="nav nav-pills flex-column secondary-navigation">
     {% for linkPath, linkLabel in links %}
     {% set classes = ['nav-link', 'rounded-0'] %}
     {% if (rootPath ~ linkPath) is activeCurrentUrl %}

--- a/src/docs/partials/secondary-navigation.html
+++ b/src/docs/partials/secondary-navigation.html
@@ -1,4 +1,4 @@
-<ul class="nav nav-pills flex-column">
+<ul class="nav nav-pills flex-column" id="secondary-navigation">
     {% for linkPath, linkLabel in links %}
     {% set classes = ['nav-link', 'rounded-0'] %}
     {% if (rootPath ~ linkPath) is activeCurrentUrl %}


### PR DESCRIPTION
Resolves: https://github.com/nihruk/design-system/issues/272

- Allows focus states and active nav link to both display, by changing active nav link from a blue background to a blue underline
- Gives nav links an underline on hover 
- Aligns the first primary nav item with the rest of the left hand margin by removing the padding on the first item only 

Evaluate by comparing: https://design-system-git-active-underlines-nihruk.vercel.app/component
Against: https://design-system.nihr.ac.uk/component